### PR TITLE
Pass license checks for TravisCI

### DIFF
--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyCssCustomRulesDefinition.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyCssCustomRulesDefinition.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyCssCustomRulesPlugin.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyCssCustomRulesPlugin.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyLessCustomRulesDefinition.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyLessCustomRulesDefinition.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyScssCustomRulesDefinition.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/MyScssCustomRulesDefinition.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/css/ForbiddenPropertiesCheck.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/css/ForbiddenPropertiesCheck.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/css/ForbiddenUrlCheck.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/css/ForbiddenUrlCheck.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/less/InterpolatedPropertiesCheck.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/less/InterpolatedPropertiesCheck.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/scss/InterpolatedPropertiesCheck.java
+++ b/its/plugin/plugins/css-custom-rules-plugin/src/main/java/org/sonar/css/checks/scss/InterpolatedPropertiesCheck.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/CssDuplicationsTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/CssDuplicationsTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/CssMetricsTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/CssMetricsTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/CustomRulesTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/CustomRulesTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/IssuesTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/IssuesTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/LessDuplicationsTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/LessDuplicationsTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/LessMetricsTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/LessMetricsTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/MinifiedTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/MinifiedTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/ScssDuplicationsTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/ScssDuplicationsTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/ScssMetricsTest.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/ScssMetricsTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/plugin/tests/src/test/java/org/sonar/css/Tests.java
+++ b/its/plugin/tests/src/test/java/org/sonar/css/Tests.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/ruling/tests/src/test/java/org/sonar/css/its/CssTest.java
+++ b/its/ruling/tests/src/test/java/org/sonar/css/its/CssTest.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/its/ruling/tests/src/test/java/org/sonar/css/its/ProfileGenerator.java
+++ b/its/ruling/tests/src/test/java/org/sonar/css/its/ProfileGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SonarQube CSS / SCSS / Less Analyzer
- * Copyright (C) 2013-2016 David RACODON and Tamas Kende
- * mailto: david.racodon@gmail.com
+ * Copyright (C) 2013-2016 Tamas Kende and David RACODON
+ * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 mvn -B clean install
 


### PR DESCRIPTION
This PR doesn't yet get all of the tests working, but it at least fixes the license issues so that TravisCI will start testing against a Sonarqube server.  (There are still LESS parser failures that I'll look into).

https://travis-ci.org/edwelker/sonar-css-plugin-copy/builds/280499467

This is a copy that I've been using to test against.  This PR contains that code.